### PR TITLE
Fixed ExitSpanMinDurationInMilliseconds constant

### DIFF
--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -28,7 +28,7 @@ namespace Elastic.Apm.Config
 			public const string CloudProvider = SupportedValues.CloudProviderAuto;
 			public const bool EnableOpenTelemetryBridge = false;
 			public const string ExitSpanMinDuration = "1ms";
-			public const int ExitSpanMinDurationInMilliseconds = 1000;
+			public const int ExitSpanMinDurationInMilliseconds = 1;
 			public const int FlushIntervalInMilliseconds = 10_000; // 10 seconds
 			public const LogLevel LogLevel = Logging.LogLevel.Error;
 			public const int MaxBatchEventCount = 10;


### PR DESCRIPTION
Fixes #1789

Fixed `DefaultValues.ExitSpanMinDurationInMilliseconds` to have correct default value of 1ms instead of 1000ms.